### PR TITLE
Bugfix/windows improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Alternatively you can run the agent as "root" user so the folder and file will b
 In a terminal session execute:
 ```
 c8ylp [params]
+
+# or launching directly via python
+python3 -m c8ylp.main
 ```
 Available Parameter:
 

--- a/c8ylp/main.py
+++ b/c8ylp/main.py
@@ -42,8 +42,10 @@ def signal_handler(signal, frame):
     raise ExitCommand()
 
 def start():
-    if platform.system() == 'Linux':
+    if platform.system() in ('Linux', 'Darwin'):
         signal.signal(signal.SIGUSR1, signal_handler)
+    else:
+        signal.signal(signal.SIGINT, signal_handler)
     home = expanduser('~')
     path = pathlib.Path(home + '/.c8ylp')
     loglevel = logging.INFO

--- a/c8ylp/websocket_client/ws_client.py
+++ b/c8ylp/websocket_client/ws_client.py
@@ -160,7 +160,10 @@ class WebsocketClient(threading.Thread):
             self.logger.info(f'Reconnect with counter {self.reconnect_counter}')
             self.reconnect()
         else:
-            os.kill(os.getpid(), signal.SIGUSR1)
+            if platform.system() in ('Linux', 'Darwin'):
+                os.kill(os.getpid(), signal.SIGUSR1)
+            else:
+                os.kill(os.getpid(), signal.SIGINT)
 
     def _on_ws_open(self, _ws):
         self.logger.info(f'WebSocket Connection opened!')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests>=2.25.1
 websocket_client>=1.1.0
 setuptools>=57.0.0
+certifi>=2020.12.5


### PR DESCRIPTION
* fixing shutdown (kill) of c8ylp on Windows once the max reconnect attempts are exceeded
* adding support for ca-certificates on Windows via the [certifi](https://pypi.org/project/certifi/) package
* adding instructions about start c8ylp from using python, i.e. `python3 -m c8ylp.main`