### PR TITLE
Bugfix/start via module

### DIFF
--- a/c8ylp/__init__.py
+++ b/c8ylp/__init__.py
@@ -1,1 +1,0 @@
-from c8ylp.main import start

--- a/c8ylp/websocket_client/ws_client.py
+++ b/c8ylp/websocket_client/ws_client.py
@@ -96,7 +96,7 @@ class WebsocketClient(threading.Thread):
             sslopt_ca_certs['cert_reqs'] = ssl.CERT_NONE
         web_socket_kwargs['sslopt'] = sslopt_ca_certs
 
-        self.logging.debug(f'websocket options: {web_socket_kwargs}')
+        self.logger.debug(f'websocket options: {web_socket_kwargs}')
 
         self.wst = threading.Thread(target=self.web_socket.run_forever, kwargs=web_socket_kwargs)
         self.wst.daemon = True


### PR DESCRIPTION
* Fixing logging bug introduced in #16
* Fixing runtime error when running c8ylp via `python3 -m c8ylp.main`
    ```sh
    C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.8_3.8.2800.0_x64__qbz5n2kfra8p0\lib\runpy.py:127: 
    RuntimeWarning: 'c8ylp.main' found in sys.modules after import of package 'c8ylp', but prior to execution of 'c8ylp.main'; this may result in unpredictable behaviour
    ````