### PR TITLE
assigning session when the token is valid

### DIFF
--- a/c8ylp/main.py
+++ b/c8ylp/main.py
@@ -161,6 +161,7 @@ def start():
     session = None
     if token:
         client.validate_token()
+        session = client.session
     else:
         session = client.retrieve_token()
     if session == None and tfacode == None:


### PR DESCRIPTION
Fixing bug where a valid token supplied by the `C8Y_TOKEN` environment variable is ignored, and results in an early exit.

The bug was introduced in 1.4.9.