### PR TITLE
Issue/login help

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,8 +4,9 @@
 name: Upload Python Package
 
 on:
+  workflow_dispatch:
   release:
-    types: [created, released]
+    types: [published]
 
 jobs:
   deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Unreleased
 
 * fix: `c8ylp login --help` no longer prompts the user for the host when trying to display the help
+* ci: Trigger GitHub publish action when a GitHub Release has been set to publish or it is manually triggered
 
 ## 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Releases
 
+## Unreleased
+
+* fix: `c8ylp login --help` no longer prompts the user for the host when trying to display the help
+
 ## 2.0.1
 
 ### Breaking changes

--- a/c8ylp/options.py
+++ b/c8ylp/options.py
@@ -120,7 +120,7 @@ HOSTNAME = click.option(
 HOSTNAME_PROMPT = click.option(
     "--host",
     "host",
-    is_eager=True,
+    is_eager=False,
     prompt=True,
     envvar=("C8Y_HOST", "C8Y_BASEURL", "C8Y_URL"),
     help="Cumulocity Hostname  [required] [env var: C8Y_HOST]",

--- a/tests/c8ylp/cli/test_login.py
+++ b/tests/c8ylp/cli/test_login.py
@@ -168,3 +168,26 @@ def test_disable_prompts(c8yserver: FixtureCumulocityAPI, env: Environment):
         assert result.exit_code == 2
 
     run()
+
+
+def test_help_without_host(env: Environment):
+    """Test display of help with providing any other options"""
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "login",
+            "--help",
+        ],
+        env={
+            **env.create_empty_env(),
+        },
+        # Use dummy stdin, so that in case the command does expect input
+        # but it should not appear in the output
+        input="dummyinput",
+    )
+
+    assert result.exit_code == 0
+    assert "Host: " not in result.output, "User should not be prompted for hostname"
+    assert "dummyinput" not in result.output, "User should not be prompted for hostname"


### PR DESCRIPTION
* fix: `c8ylp login --help` no longer prompts the user for the host when trying to display the help
* ci: Trigger GitHub publish action when a GitHub Release has been set to publish or it is manually triggered