### PR TITLE
fix: tenant id detection on sso enabled tenants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Releases
 
+## Current
+
+* fix: Tenant id detection works as expected even when SSO is enabled on a tenant is appears before the INTERNAL_OAUTH2 option in /tenant/loginOptions.
+
 ## 2.0.3
 
 * fix: The Cumulocity host is now normalized by trimming whitespace and trailing forward slashes

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -60,9 +60,13 @@ class FixtureCumulocityAPI:
             json={
                 "loginOptions": [
                     {
-                        "initRequest": f"example?tenantId={tenant or self.tenant}",
+                        "initRequest": f"example?response_type=code&tenant_id={tenant or self.tenant}",
+                        "type": "OAUTH2",
+                    },
+                    {
+                        "initRequest": f"example?tenant_id={tenant or self.tenant}",
                         "type": "OAUTH2_INTERNAL",
-                    }
+                    },
                 ]
             },
             status=200,


### PR DESCRIPTION
* fix: Tenant id detection works as expected even when SSO is enabled on a tenant is appears before the INTERNAL_OAUTH2 option in /tenant/loginOptions.

Error would appear when the user tried to use any command, and the tenant id would be incorrectly detected.
```
[c8ylp] WARNING Wrong Tenant ID t1564, Correct Tenant ID: code&tenant_id=t12345
```