### PR TITLE
Fix/disable reconnects

### DIFF
--- a/c8ylp/cli/core.py
+++ b/c8ylp/cli/core.py
@@ -82,7 +82,6 @@ class ProxyContext:
     tcp_timeout = 0
     verbose = False
     ignore_ssl_validate = False
-    reconnects = 0
     ssh_user = ""
     additional_args = None
     disable_prompts = False
@@ -628,7 +627,6 @@ def start_proxy(
         "token": opts.token,
         "ignore_ssl_validate": opts.ignore_ssl_validate,
         "ping_interval": opts.ping_interval,
-        "max_retries": opts.reconnects,
     }
 
     tcp_server = None

--- a/c8ylp/cli/core.py
+++ b/c8ylp/cli/core.py
@@ -628,7 +628,7 @@ def start_proxy(
         "token": opts.token,
         "ignore_ssl_validate": opts.ignore_ssl_validate,
         "ping_interval": opts.ping_interval,
-        "max_retries": 2,
+        "max_retries": opts.reconnects,
     }
 
     tcp_server = None

--- a/c8ylp/options.py
+++ b/c8ylp/options.py
@@ -314,16 +314,6 @@ SSL_IGNORE_VERIFY = click.option(
 )
 
 
-SERVER_RECONNECT_LIMIT = click.option(
-    "--reconnects",
-    envvar="C8YLP_RECONNECTS",
-    type=click.IntRange(-1, 10),
-    default=5,
-    show_default=True,
-    show_envvar=True,
-    help="number of reconnects to the Cloud Remote Service. 0 for infinite reconnects, -1 for no reconnects",
-)
-
 SSH_USER = click.option(
     "--ssh-user",
     envvar="C8YLP_SSH_USER",
@@ -392,7 +382,6 @@ def common_options(f):
         SSL_IGNORE_VERIFY,
         STORE_TOKEN,
         DISABLE_PROMPT,
-        SERVER_RECONNECT_LIMIT,
     ]
 
     # Need to reverse the order to control the list order

--- a/c8ylp/options.py
+++ b/c8ylp/options.py
@@ -321,7 +321,7 @@ SERVER_RECONNECT_LIMIT = click.option(
     default=5,
     show_default=True,
     show_envvar=True,
-    help="number of reconnects to the Cloud Remote Service. 0 for infinite reconnects",
+    help="number of reconnects to the Cloud Remote Service. 0 for infinite reconnects, -1 for no reconnects",
 )
 
 SSH_USER = click.option(

--- a/c8ylp/tcp_socket/tcp_server.py
+++ b/c8ylp/tcp_socket/tcp_server.py
@@ -81,6 +81,7 @@ class TCPHandler(socketserver.BaseRequestHandler):
                 if not data:
                     logging.debug("No data. Request will be closed")
                     self.server.web_socket_client.proxy_send_message = None
+                    self.server.web_socket_client.stop()
                     break
 
                 logging.debug("Writing data to ws: %s", data)

--- a/c8ylp/tcp_socket/tcp_server.py
+++ b/c8ylp/tcp_socket/tcp_server.py
@@ -46,7 +46,9 @@ class TCPHandler(socketserver.BaseRequestHandler):
 
         def handle_shutdown():
             # Force shutdown of any socket reads or writes
-            request.shutdown(socket.SHUT_RDWR)
+            # Note: fileno is set to -1 if the socket has been closed
+            if request.fileno() != -1:
+                request.shutdown(socket.SHUT_RDWR)
 
         self.server.web_socket_client.shutdown_request = handle_shutdown
 

--- a/c8ylp/websocket_client/ws_client.py
+++ b/c8ylp/websocket_client/ws_client.py
@@ -174,7 +174,9 @@ class WebsocketClient(threading.Thread):
         if self.web_socket:
             self.web_socket.close()
 
-        if self.max_retries > -1 and self.connection_attempts >= self.max_retries:
+        if self.max_retries == -1 or (
+            self.max_retries != 0 and self.connection_attempts >= self.max_retries
+        ):
             if callable(self.shutdown_request):
                 self.logger.debug("Websocket is requesting the server to stop")
                 self.shutdown_request()

--- a/c8ylp/websocket_client/ws_client.py
+++ b/c8ylp/websocket_client/ws_client.py
@@ -272,7 +272,8 @@ class WebsocketClient(threading.Thread):
         )
         self._ws_open_event.clear()
         self._connection_timer_cancel()
-        self.reconnect()
+        # TODO Do we really need this any longer?
+        #self.reconnect()
 
     def _reset_connection_attempts(self):
         """Reset the connection attempts by using a stability timer to ensure that the

--- a/c8ylp/websocket_client/ws_client.py
+++ b/c8ylp/websocket_client/ws_client.py
@@ -272,8 +272,6 @@ class WebsocketClient(threading.Thread):
         )
         self._ws_open_event.clear()
         self._connection_timer_cancel()
-        # TODO Do we really need this any longer?
-        #self.reconnect()
 
     def _reset_connection_attempts(self):
         """Reset the connection attempts by using a stability timer to ensure that the

--- a/c8ylp/websocket_client/ws_client.py
+++ b/c8ylp/websocket_client/ws_client.py
@@ -71,7 +71,6 @@ class WebsocketClient(threading.Thread):
         token,
         ignore_ssl_validate=False,
         ping_interval=0,
-        max_retries=0,
         shutdown_request=None,
     ):
         self.host = host
@@ -90,11 +89,7 @@ class WebsocketClient(threading.Thread):
         self.token = token
         self.ws_handshake_error = False
         self.ignore_ssl_validate = ignore_ssl_validate
-        self.max_retries = max_retries
-        self.connection_attempts = 0
         self.shutdown_request = shutdown_request
-        self._connection_stable_timer = None
-        self._connection_stable_sec = 10
 
         self.proxy_send_message: Callable = None
         super().__init__()
@@ -102,9 +97,6 @@ class WebsocketClient(threading.Thread):
     def connect(self):
         """Connect websocket"""
         self._ws_open_event.clear()
-
-        # increment before logic as when reconnect is called, then it
-        self.connection_attempts += 1
 
         # websocket.enableTrace(True) # Enable this for Debug Purpose only
         if self.host.startswith("https"):
@@ -168,29 +160,6 @@ class WebsocketClient(threading.Thread):
         self.wst.name = f"WSTunnelThread-{self.config_id}"
         self.wst.start()
         return self
-
-    def reconnect(self):
-        """Reconnect websocket"""
-        if self.web_socket:
-            self.web_socket.close()
-
-        if self.max_retries == -1 or (
-            self.max_retries != 0 and self.connection_attempts >= self.max_retries
-        ):
-            if callable(self.shutdown_request):
-                self.logger.debug("Websocket is requesting the server to stop")
-                self.shutdown_request()
-
-            return
-
-        self.logger.info(
-            "Reconnecting to WebSocket: reconnects=%d, max=%d",
-            self.connection_attempts,
-            self.max_retries,
-        )
-
-        self.web_socket = None
-        self.connect()
 
     def stop(self):
         """Stop websocket"""
@@ -271,37 +240,7 @@ class WebsocketClient(threading.Thread):
             reason,
         )
         self._ws_open_event.clear()
-        self._connection_timer_cancel()
-
-    def _reset_connection_attempts(self):
-        """Reset the connection attempts by using a stability timer to ensure that the
-        connection is running for a minimum period before the connection attempts
-        counter is reset.
-
-        This avoids problems when the device side proxy establishing a connection briefly
-        and then closes it due to local device problems such as the ssh daemon not running
-        on the device.
-        """
-
-        def reset_connection_attempts():
-            self.connection_attempts = 0
-
-        if not self._connection_stable_timer:
-            self._connection_stable_timer = threading.Timer(
-                self._connection_stable_sec,
-                reset_connection_attempts,
-            )
-            self._connection_stable_timer.setName("ws-stable-connection-timer")
-            self._connection_stable_timer.daemon = True
-            self._connection_stable_timer.start()
-
-    def _connection_timer_cancel(self):
-        """Cancel the connection stability timer (if it is already set)"""
-        if self._connection_stable_timer is not None:
-            self._connection_stable_timer.cancel()
-            self._connection_stable_timer = None
 
     def _on_ws_open(self, _ws):
         self.logger.info("WebSocket Connection opened")
-        self._reset_connection_attempts()
         self._ws_open_event.set()

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -112,6 +112,14 @@ Execute the integration tests by following the procedure below:
     invoke test-integration
     ```
 
+### Installing c8ylp from a specific branch
+
+To install c8ylp from a development use the following command (replace `<branch>` with the name of your branch you want to install from.)
+
+```sh
+pip install git+https://github.com/SoftwareAG/cumulocity-remote-access-local-proxy.git@<branch>
+```
+
 ## CLI Documentation
 
 The CLI commands are also documented in the project in the form of markdown files (for online viewing). After changing any of the commands (or adding new ones), the documentation should be updated using the following:

--- a/docs/cli/C8YLP_CONNECT_SSH.md
+++ b/docs/cli/C8YLP_CONNECT_SSH.md
@@ -29,46 +29,42 @@ Usage: c8ylp connect ssh [OPTIONS] DEVICE [REMOTE_COMMANDS]...
       c8ylp connect ssh device01 --env-file .env --ssh-user admin -- "systemctl status ssh; dpkg --list | grep ssh"
 
 Options:
-  --host TEXT                 Cumulocity Hostname  [required] [env var:
-                              C8Y_HOST]
-  -t, --tenant TEXT           Cumulocity tenant id  [env var: C8Y_TENANT]
-  -u, --user TEXT             Cumulocity username  [env var: C8Y_USER,
-                              C8Y_USERNAME]
-  -t, --token TEXT            Cumulocity token  [env var: C8Y_TOKEN]
-  -p, --password TEXT         Cumulocity password  [env var: C8Y_PASSWORD]
-  --tfa-code TEXT             TFA Code. Required when the 'TFA enabled' is
-                              enabled for a user  [env var: C8Y_TFA_CODE]
-  --env-file PATH             Environment file to load. Any settings loaded
-                              via this file will control other options  [env
-                              var: C8YLP_ENV_FILE]
-  --external-type TEXT        external Id Type  [env var: C8YLP_EXTERNAL_TYPE;
-                              default: c8y_Serial]
-  -c, --config TEXT           name of the C8Y Remote Access Configuration
-                              [env var: C8YLP_CONFIG; default: Passthrough]
-  --port INTEGER RANGE        TCP Port which should be opened. 0=Random port
-                              [env var: C8YLP_PORT; default: 0; 0<=x<=65535]
-  --ping-interval INTEGER     Websocket ping interval in seconds. 0=disabled
-                              [env var: C8YLP_PING_INTERVAL; default: 0]
-  --tcp-size INTEGER RANGE    TCP Package Size  [env var: C8YLP_TCP_SIZE;
-                              default: 4096; 1024<=x<=8290304]
-  --tcp-timeout INTEGER       Timeout in sec. for inactivity. Can be activated
-                              with values > 0  [env var: C8YLP_TCP_TIMEOUT;
-                              default: 0]
-  -v, --verbose               Print Debug Information into the Logs and
-                              Console when set  [env var: C8YLP_VERBOSE]
-  --ignore-ssl-validate       Ignore Validation for SSL Certificates while
-                              connecting to Websocket  [env var:
-                              C8YLP_IGNORE_SSL_VALIDATE]
-  --store-token               Store the Cumulocity host, tenant and token to
-                              the env-file if a file is being used  [env var:
-                              C8YLP_STORE_TOKEN]
-  -d, --disable-prompts       [env var: C8YLP_DISABLE_PROMPTS]
-  --reconnects INTEGER RANGE  number of reconnects to the Cloud Remote
-                              Service. 0 for infinite reconnects, -1 for no
-                              reconnects  [env var: C8YLP_RECONNECTS; default:
-                              5; -1<=x<=10]
-  --ssh-user TEXT             SSH username which is configured on the device
-                              [required]
-  -h, --help                  Show this message and exit.
+  --host TEXT               Cumulocity Hostname  [required] [env var:
+                            C8Y_HOST]
+  -t, --tenant TEXT         Cumulocity tenant id  [env var: C8Y_TENANT]
+  -u, --user TEXT           Cumulocity username  [env var: C8Y_USER,
+                            C8Y_USERNAME]
+  -t, --token TEXT          Cumulocity token  [env var: C8Y_TOKEN]
+  -p, --password TEXT       Cumulocity password  [env var: C8Y_PASSWORD]
+  --tfa-code TEXT           TFA Code. Required when the 'TFA enabled' is
+                            enabled for a user  [env var: C8Y_TFA_CODE]
+  --env-file PATH           Environment file to load. Any settings loaded via
+                            this file will control other options  [env var:
+                            C8YLP_ENV_FILE]
+  --external-type TEXT      external Id Type  [env var: C8YLP_EXTERNAL_TYPE;
+                            default: c8y_Serial]
+  -c, --config TEXT         name of the C8Y Remote Access Configuration  [env
+                            var: C8YLP_CONFIG; default: Passthrough]
+  --port INTEGER RANGE      TCP Port which should be opened. 0=Random port
+                            [env var: C8YLP_PORT; default: 0; 0<=x<=65535]
+  --ping-interval INTEGER   Websocket ping interval in seconds. 0=disabled
+                            [env var: C8YLP_PING_INTERVAL; default: 0]
+  --tcp-size INTEGER RANGE  TCP Package Size  [env var: C8YLP_TCP_SIZE;
+                            default: 4096; 1024<=x<=8290304]
+  --tcp-timeout INTEGER     Timeout in sec. for inactivity. Can be activated
+                            with values > 0  [env var: C8YLP_TCP_TIMEOUT;
+                            default: 0]
+  -v, --verbose             Print Debug Information into the Logs and Console
+                            when set  [env var: C8YLP_VERBOSE]
+  --ignore-ssl-validate     Ignore Validation for SSL Certificates while
+                            connecting to Websocket  [env var:
+                            C8YLP_IGNORE_SSL_VALIDATE]
+  --store-token             Store the Cumulocity host, tenant and token to the
+                            env-file if a file is being used  [env var:
+                            C8YLP_STORE_TOKEN]
+  -d, --disable-prompts     [env var: C8YLP_DISABLE_PROMPTS]
+  --ssh-user TEXT           SSH username which is configured on the device
+                            [required]
+  -h, --help                Show this message and exit.
 
 ```

--- a/docs/cli/C8YLP_CONNECT_SSH.md
+++ b/docs/cli/C8YLP_CONNECT_SSH.md
@@ -64,8 +64,9 @@ Options:
                               C8YLP_STORE_TOKEN]
   -d, --disable-prompts       [env var: C8YLP_DISABLE_PROMPTS]
   --reconnects INTEGER RANGE  number of reconnects to the Cloud Remote
-                              Service. 0 for infinite reconnects  [env var:
-                              C8YLP_RECONNECTS; default: 5; -1<=x<=10]
+                              Service. 0 for infinite reconnects, -1 for no
+                              reconnects  [env var: C8YLP_RECONNECTS; default:
+                              5; -1<=x<=10]
   --ssh-user TEXT             SSH username which is configured on the device
                               [required]
   -h, --help                  Show this message and exit.

--- a/docs/cli/C8YLP_PLUGIN_COMMAND.md
+++ b/docs/cli/C8YLP_PLUGIN_COMMAND.md
@@ -30,44 +30,40 @@ Usage: c8ylp plugin command [OPTIONS] DEVICE [REMOTE_COMMANDS]...
           c8ylp plugin command --env-file .env -v device01 ./copyfrom.sh /var/log/dpkg.log ./
 
 Options:
-  --host TEXT                 Cumulocity Hostname  [required] [env var:
-                              C8Y_HOST]
-  -t, --tenant TEXT           Cumulocity tenant id  [env var: C8Y_TENANT]
-  -u, --user TEXT             Cumulocity username  [env var: C8Y_USER,
-                              C8Y_USERNAME]
-  -t, --token TEXT            Cumulocity token  [env var: C8Y_TOKEN]
-  -p, --password TEXT         Cumulocity password  [env var: C8Y_PASSWORD]
-  --tfa-code TEXT             TFA Code. Required when the 'TFA enabled' is
-                              enabled for a user  [env var: C8Y_TFA_CODE]
-  --env-file PATH             Environment file to load. Any settings loaded
-                              via this file will control other options  [env
-                              var: C8YLP_ENV_FILE]
-  --external-type TEXT        external Id Type  [env var: C8YLP_EXTERNAL_TYPE;
-                              default: c8y_Serial]
-  -c, --config TEXT           name of the C8Y Remote Access Configuration
-                              [env var: C8YLP_CONFIG; default: Passthrough]
-  --port INTEGER RANGE        TCP Port which should be opened. 0=Random port
-                              [env var: C8YLP_PORT; default: 0; 0<=x<=65535]
-  --ping-interval INTEGER     Websocket ping interval in seconds. 0=disabled
-                              [env var: C8YLP_PING_INTERVAL; default: 0]
-  --tcp-size INTEGER RANGE    TCP Package Size  [env var: C8YLP_TCP_SIZE;
-                              default: 4096; 1024<=x<=8290304]
-  --tcp-timeout INTEGER       Timeout in sec. for inactivity. Can be activated
-                              with values > 0  [env var: C8YLP_TCP_TIMEOUT;
-                              default: 0]
-  -v, --verbose               Print Debug Information into the Logs and
-                              Console when set  [env var: C8YLP_VERBOSE]
-  --ignore-ssl-validate       Ignore Validation for SSL Certificates while
-                              connecting to Websocket  [env var:
-                              C8YLP_IGNORE_SSL_VALIDATE]
-  --store-token               Store the Cumulocity host, tenant and token to
-                              the env-file if a file is being used  [env var:
-                              C8YLP_STORE_TOKEN]
-  -d, --disable-prompts       [env var: C8YLP_DISABLE_PROMPTS]
-  --reconnects INTEGER RANGE  number of reconnects to the Cloud Remote
-                              Service. 0 for infinite reconnects, -1 for no
-                              reconnects  [env var: C8YLP_RECONNECTS; default:
-                              5; -1<=x<=10]
-  -h, --help                  Show this message and exit.
+  --host TEXT               Cumulocity Hostname  [required] [env var:
+                            C8Y_HOST]
+  -t, --tenant TEXT         Cumulocity tenant id  [env var: C8Y_TENANT]
+  -u, --user TEXT           Cumulocity username  [env var: C8Y_USER,
+                            C8Y_USERNAME]
+  -t, --token TEXT          Cumulocity token  [env var: C8Y_TOKEN]
+  -p, --password TEXT       Cumulocity password  [env var: C8Y_PASSWORD]
+  --tfa-code TEXT           TFA Code. Required when the 'TFA enabled' is
+                            enabled for a user  [env var: C8Y_TFA_CODE]
+  --env-file PATH           Environment file to load. Any settings loaded via
+                            this file will control other options  [env var:
+                            C8YLP_ENV_FILE]
+  --external-type TEXT      external Id Type  [env var: C8YLP_EXTERNAL_TYPE;
+                            default: c8y_Serial]
+  -c, --config TEXT         name of the C8Y Remote Access Configuration  [env
+                            var: C8YLP_CONFIG; default: Passthrough]
+  --port INTEGER RANGE      TCP Port which should be opened. 0=Random port
+                            [env var: C8YLP_PORT; default: 0; 0<=x<=65535]
+  --ping-interval INTEGER   Websocket ping interval in seconds. 0=disabled
+                            [env var: C8YLP_PING_INTERVAL; default: 0]
+  --tcp-size INTEGER RANGE  TCP Package Size  [env var: C8YLP_TCP_SIZE;
+                            default: 4096; 1024<=x<=8290304]
+  --tcp-timeout INTEGER     Timeout in sec. for inactivity. Can be activated
+                            with values > 0  [env var: C8YLP_TCP_TIMEOUT;
+                            default: 0]
+  -v, --verbose             Print Debug Information into the Logs and Console
+                            when set  [env var: C8YLP_VERBOSE]
+  --ignore-ssl-validate     Ignore Validation for SSL Certificates while
+                            connecting to Websocket  [env var:
+                            C8YLP_IGNORE_SSL_VALIDATE]
+  --store-token             Store the Cumulocity host, tenant and token to the
+                            env-file if a file is being used  [env var:
+                            C8YLP_STORE_TOKEN]
+  -d, --disable-prompts     [env var: C8YLP_DISABLE_PROMPTS]
+  -h, --help                Show this message and exit.
 
 ```

--- a/docs/cli/C8YLP_PLUGIN_COMMAND.md
+++ b/docs/cli/C8YLP_PLUGIN_COMMAND.md
@@ -65,8 +65,9 @@ Options:
                               C8YLP_STORE_TOKEN]
   -d, --disable-prompts       [env var: C8YLP_DISABLE_PROMPTS]
   --reconnects INTEGER RANGE  number of reconnects to the Cloud Remote
-                              Service. 0 for infinite reconnects  [env var:
-                              C8YLP_RECONNECTS; default: 5; -1<=x<=10]
+                              Service. 0 for infinite reconnects, -1 for no
+                              reconnects  [env var: C8YLP_RECONNECTS; default:
+                              5; -1<=x<=10]
   -h, --help                  Show this message and exit.
 
 ```

--- a/docs/cli/C8YLP_SERVER.md
+++ b/docs/cli/C8YLP_SERVER.md
@@ -59,8 +59,9 @@ Options:
                               C8YLP_STORE_TOKEN]
   -d, --disable-prompts       [env var: C8YLP_DISABLE_PROMPTS]
   --reconnects INTEGER RANGE  number of reconnects to the Cloud Remote
-                              Service. 0 for infinite reconnects  [env var:
-                              C8YLP_RECONNECTS; default: 5; -1<=x<=10]
+                              Service. 0 for infinite reconnects, -1 for no
+                              reconnects  [env var: C8YLP_RECONNECTS; default:
+                              5; -1<=x<=10]
   -h, --help                  Show this message and exit.
 
 ```

--- a/docs/cli/C8YLP_SERVER.md
+++ b/docs/cli/C8YLP_SERVER.md
@@ -24,44 +24,40 @@ Usage: c8ylp server [OPTIONS] DEVICE
           c8ylp server --env-file .env --port 0 device01
 
 Options:
-  --host TEXT                 Cumulocity Hostname  [required] [env var:
-                              C8Y_HOST]
-  -t, --tenant TEXT           Cumulocity tenant id  [env var: C8Y_TENANT]
-  -u, --user TEXT             Cumulocity username  [env var: C8Y_USER,
-                              C8Y_USERNAME]
-  -t, --token TEXT            Cumulocity token  [env var: C8Y_TOKEN]
-  -p, --password TEXT         Cumulocity password  [env var: C8Y_PASSWORD]
-  --tfa-code TEXT             TFA Code. Required when the 'TFA enabled' is
-                              enabled for a user  [env var: C8Y_TFA_CODE]
-  --env-file PATH             Environment file to load. Any settings loaded
-                              via this file will control other options  [env
-                              var: C8YLP_ENV_FILE]
-  --external-type TEXT        external Id Type  [env var: C8YLP_EXTERNAL_TYPE;
-                              default: c8y_Serial]
-  -c, --config TEXT           name of the C8Y Remote Access Configuration
-                              [env var: C8YLP_CONFIG; default: Passthrough]
-  --port INTEGER RANGE        TCP Port which should be opened. 0=Random port
-                              [env var: C8YLP_PORT; default: 0; 0<=x<=65535]
-  --ping-interval INTEGER     Websocket ping interval in seconds. 0=disabled
-                              [env var: C8YLP_PING_INTERVAL; default: 0]
-  --tcp-size INTEGER RANGE    TCP Package Size  [env var: C8YLP_TCP_SIZE;
-                              default: 4096; 1024<=x<=8290304]
-  --tcp-timeout INTEGER       Timeout in sec. for inactivity. Can be activated
-                              with values > 0  [env var: C8YLP_TCP_TIMEOUT;
-                              default: 0]
-  -v, --verbose               Print Debug Information into the Logs and
-                              Console when set  [env var: C8YLP_VERBOSE]
-  --ignore-ssl-validate       Ignore Validation for SSL Certificates while
-                              connecting to Websocket  [env var:
-                              C8YLP_IGNORE_SSL_VALIDATE]
-  --store-token               Store the Cumulocity host, tenant and token to
-                              the env-file if a file is being used  [env var:
-                              C8YLP_STORE_TOKEN]
-  -d, --disable-prompts       [env var: C8YLP_DISABLE_PROMPTS]
-  --reconnects INTEGER RANGE  number of reconnects to the Cloud Remote
-                              Service. 0 for infinite reconnects, -1 for no
-                              reconnects  [env var: C8YLP_RECONNECTS; default:
-                              5; -1<=x<=10]
-  -h, --help                  Show this message and exit.
+  --host TEXT               Cumulocity Hostname  [required] [env var:
+                            C8Y_HOST]
+  -t, --tenant TEXT         Cumulocity tenant id  [env var: C8Y_TENANT]
+  -u, --user TEXT           Cumulocity username  [env var: C8Y_USER,
+                            C8Y_USERNAME]
+  -t, --token TEXT          Cumulocity token  [env var: C8Y_TOKEN]
+  -p, --password TEXT       Cumulocity password  [env var: C8Y_PASSWORD]
+  --tfa-code TEXT           TFA Code. Required when the 'TFA enabled' is
+                            enabled for a user  [env var: C8Y_TFA_CODE]
+  --env-file PATH           Environment file to load. Any settings loaded via
+                            this file will control other options  [env var:
+                            C8YLP_ENV_FILE]
+  --external-type TEXT      external Id Type  [env var: C8YLP_EXTERNAL_TYPE;
+                            default: c8y_Serial]
+  -c, --config TEXT         name of the C8Y Remote Access Configuration  [env
+                            var: C8YLP_CONFIG; default: Passthrough]
+  --port INTEGER RANGE      TCP Port which should be opened. 0=Random port
+                            [env var: C8YLP_PORT; default: 0; 0<=x<=65535]
+  --ping-interval INTEGER   Websocket ping interval in seconds. 0=disabled
+                            [env var: C8YLP_PING_INTERVAL; default: 0]
+  --tcp-size INTEGER RANGE  TCP Package Size  [env var: C8YLP_TCP_SIZE;
+                            default: 4096; 1024<=x<=8290304]
+  --tcp-timeout INTEGER     Timeout in sec. for inactivity. Can be activated
+                            with values > 0  [env var: C8YLP_TCP_TIMEOUT;
+                            default: 0]
+  -v, --verbose             Print Debug Information into the Logs and Console
+                            when set  [env var: C8YLP_VERBOSE]
+  --ignore-ssl-validate     Ignore Validation for SSL Certificates while
+                            connecting to Websocket  [env var:
+                            C8YLP_IGNORE_SSL_VALIDATE]
+  --store-token             Store the Cumulocity host, tenant and token to the
+                            env-file if a file is being used  [env var:
+                            C8YLP_STORE_TOKEN]
+  -d, --disable-prompts     [env var: C8YLP_DISABLE_PROMPTS]
+  -h, --help                Show this message and exit.
 
 ```

--- a/tasks.py
+++ b/tasks.py
@@ -36,7 +36,7 @@ def clean(c, docs=False, bytecode=False, extra=""):
     if extra:
         patterns.append(extra)
     for pattern in patterns:
-        for match in Path('.').glob(pattern):
+        for match in Path(".").glob(pattern):
             if match.is_file():
                 match.unlink(missing_ok=True)
             else:

--- a/tasks.py
+++ b/tasks.py
@@ -18,6 +18,7 @@
 """Tasks"""
 import os
 import re
+import shutil
 import subprocess
 import sys
 from invoke import task
@@ -26,7 +27,7 @@ from pathlib import Path
 
 @task
 def clean(c, docs=False, bytecode=False, extra=""):
-    """Clean project (linux only)"""
+    """Clean project"""
     patterns = ["build", "dist", "test_output", "deb_dist", "c8ylp*tar.gz"]
     if docs:
         patterns.append("docs/cli")
@@ -35,7 +36,11 @@ def clean(c, docs=False, bytecode=False, extra=""):
     if extra:
         patterns.append(extra)
     for pattern in patterns:
-        c.run("rm -rf {}".format(pattern))
+        for match in Path('.').glob(pattern):
+            if match.is_file():
+                match.unlink(missing_ok=True)
+            else:
+                shutil.rmtree(match)
 
 
 @task


### PR DESCRIPTION
* fix: Shutdown websocket when the tcp client terminates. #38
* fix: Removed `--reconnects` option as the websocket connection should not be reattempted after it is established as it causes problems with different clients.
