### PR TITLE
Issue 45/duplicate t option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 # Releases
 
+## Current
+
+* Remove duplicated `-t` shorthand option for the `--token` option. Fixes #45
+* Add new option to disable storage of token in an dotenv file using `--no-store-token` (opposite of the existing `--store-token` option)
+
+
 ## 2.1.2
 
 * fix: Only display deprecation warning for `reconnects` option when it is used.

--- a/c8ylp/options.py
+++ b/c8ylp/options.py
@@ -219,7 +219,6 @@ C8Y_USER = click.option(
 
 C8Y_TOKEN = click.option(
     "--token",
-    "-t",
     callback=validate_token,
     envvar="C8Y_TOKEN",
     is_eager=True,
@@ -304,7 +303,7 @@ LOGGING_VERBOSE = click.option(
 )
 
 STORE_TOKEN = click.option(
-    "--store-token",
+    "--store-token/--no-store-token",
     "store_token",
     envvar="C8YLP_STORE_TOKEN",
     is_flag=True,

--- a/docs/cli/C8YLP_CONNECT_SSH.md
+++ b/docs/cli/C8YLP_CONNECT_SSH.md
@@ -29,42 +29,46 @@ Usage: c8ylp connect ssh [OPTIONS] DEVICE [REMOTE_COMMANDS]...
       c8ylp connect ssh device01 --env-file .env --ssh-user admin -- "systemctl status ssh; dpkg --list | grep ssh"
 
 Options:
-  --host TEXT               Cumulocity Hostname  [required] [env var:
-                            C8Y_HOST]
-  -t, --tenant TEXT         Cumulocity tenant id  [env var: C8Y_TENANT]
-  -u, --user TEXT           Cumulocity username  [env var: C8Y_USER,
-                            C8Y_USERNAME]
-  -t, --token TEXT          Cumulocity token  [env var: C8Y_TOKEN]
-  -p, --password TEXT       Cumulocity password  [env var: C8Y_PASSWORD]
-  --tfa-code TEXT           TFA Code. Required when the 'TFA enabled' is
-                            enabled for a user  [env var: C8Y_TFA_CODE]
-  --env-file PATH           Environment file to load. Any settings loaded via
-                            this file will control other options  [env var:
-                            C8YLP_ENV_FILE]
-  --external-type TEXT      external Id Type  [env var: C8YLP_EXTERNAL_TYPE;
-                            default: c8y_Serial]
-  -c, --config TEXT         name of the C8Y Remote Access Configuration  [env
-                            var: C8YLP_CONFIG; default: Passthrough]
-  --port INTEGER RANGE      TCP Port which should be opened. 0=Random port
-                            [env var: C8YLP_PORT; default: 0; 0<=x<=65535]
-  --ping-interval INTEGER   Websocket ping interval in seconds. 0=disabled
-                            [env var: C8YLP_PING_INTERVAL; default: 0]
-  --tcp-size INTEGER RANGE  TCP Package Size  [env var: C8YLP_TCP_SIZE;
-                            default: 4096; 1024<=x<=8290304]
-  --tcp-timeout INTEGER     Timeout in sec. for inactivity. Can be activated
-                            with values > 0  [env var: C8YLP_TCP_TIMEOUT;
-                            default: 0]
-  -v, --verbose             Print Debug Information into the Logs and Console
-                            when set  [env var: C8YLP_VERBOSE]
-  --ignore-ssl-validate     Ignore Validation for SSL Certificates while
-                            connecting to Websocket  [env var:
-                            C8YLP_IGNORE_SSL_VALIDATE]
-  --store-token             Store the Cumulocity host, tenant and token to the
-                            env-file if a file is being used  [env var:
-                            C8YLP_STORE_TOKEN]
-  -d, --disable-prompts     [env var: C8YLP_DISABLE_PROMPTS]
-  --ssh-user TEXT           SSH username which is configured on the device
-                            [required]
-  -h, --help                Show this message and exit.
+  --host TEXT                     Cumulocity Hostname  [required] [env var:
+                                  C8Y_HOST]
+  -t, --tenant TEXT               Cumulocity tenant id  [env var: C8Y_TENANT]
+  -u, --user TEXT                 Cumulocity username  [env var: C8Y_USER,
+                                  C8Y_USERNAME]
+  --token TEXT                    Cumulocity token  [env var: C8Y_TOKEN]
+  -p, --password TEXT             Cumulocity password  [env var: C8Y_PASSWORD]
+  --tfa-code TEXT                 TFA Code. Required when the 'TFA enabled' is
+                                  enabled for a user  [env var: C8Y_TFA_CODE]
+  --env-file PATH                 Environment file to load. Any settings
+                                  loaded via this file will control other
+                                  options  [env var: C8YLP_ENV_FILE]
+  --external-type TEXT            external Id Type  [env var:
+                                  C8YLP_EXTERNAL_TYPE; default: c8y_Serial]
+  -c, --config TEXT               name of the C8Y Remote Access Configuration
+                                  [env var: C8YLP_CONFIG; default:
+                                  Passthrough]
+  --port INTEGER RANGE            TCP Port which should be opened. 0=Random
+                                  port  [env var: C8YLP_PORT; default: 0;
+                                  0<=x<=65535]
+  --ping-interval INTEGER         Websocket ping interval in seconds.
+                                  0=disabled  [env var: C8YLP_PING_INTERVAL;
+                                  default: 0]
+  --tcp-size INTEGER RANGE        TCP Package Size  [env var: C8YLP_TCP_SIZE;
+                                  default: 4096; 1024<=x<=8290304]
+  --tcp-timeout INTEGER           Timeout in sec. for inactivity. Can be
+                                  activated with values > 0  [env var:
+                                  C8YLP_TCP_TIMEOUT; default: 0]
+  -v, --verbose                   Print Debug Information into the Logs and
+                                  Console when set  [env var: C8YLP_VERBOSE]
+  --ignore-ssl-validate           Ignore Validation for SSL Certificates while
+                                  connecting to Websocket  [env var:
+                                  C8YLP_IGNORE_SSL_VALIDATE]
+  --store-token / --no-store-token
+                                  Store the Cumulocity host, tenant and token
+                                  to the env-file if a file is being used
+                                  [env var: C8YLP_STORE_TOKEN]
+  -d, --disable-prompts           [env var: C8YLP_DISABLE_PROMPTS]
+  --ssh-user TEXT                 SSH username which is configured on the
+                                  device  [required]
+  -h, --help                      Show this message and exit.
 
 ```

--- a/docs/cli/C8YLP_LOGIN.md
+++ b/docs/cli/C8YLP_LOGIN.md
@@ -14,23 +14,25 @@ Usage: c8ylp login [OPTIONS]
       c8ylp login --env-file mytenant.env
 
 Options:
-  --host TEXT            Cumulocity Hostname  [required] [env var: C8Y_HOST]
-  -t, --tenant TEXT      Cumulocity tenant id  [env var: C8Y_TENANT]
-  -u, --user TEXT        Cumulocity username  [env var: C8Y_USER,
-                         C8Y_USERNAME]
-  -t, --token TEXT       Cumulocity token  [env var: C8Y_TOKEN]
-  -p, --password TEXT    Cumulocity password  [env var: C8Y_PASSWORD]
-  --tfa-code TEXT        TFA Code. Required when the 'TFA enabled' is enabled
-                         for a user  [env var: C8Y_TFA_CODE]
-  -v, --verbose          Print Debug Information into the Logs and Console
-                         when set  [env var: C8YLP_VERBOSE]
-  --env-file PATH        Environment file to load. Any settings loaded via
-                         this file will control other options  [env var:
-                         C8YLP_ENV_FILE]
-  --store-token          Store the Cumulocity host, tenant and token to the
-                         env-file if a file is being used  [env var:
-                         C8YLP_STORE_TOKEN]
-  -d, --disable-prompts  [env var: C8YLP_DISABLE_PROMPTS]
-  -h, --help             Show this message and exit.
+  --host TEXT                     Cumulocity Hostname  [required] [env var:
+                                  C8Y_HOST]
+  -t, --tenant TEXT               Cumulocity tenant id  [env var: C8Y_TENANT]
+  -u, --user TEXT                 Cumulocity username  [env var: C8Y_USER,
+                                  C8Y_USERNAME]
+  --token TEXT                    Cumulocity token  [env var: C8Y_TOKEN]
+  -p, --password TEXT             Cumulocity password  [env var: C8Y_PASSWORD]
+  --tfa-code TEXT                 TFA Code. Required when the 'TFA enabled' is
+                                  enabled for a user  [env var: C8Y_TFA_CODE]
+  -v, --verbose                   Print Debug Information into the Logs and
+                                  Console when set  [env var: C8YLP_VERBOSE]
+  --env-file PATH                 Environment file to load. Any settings
+                                  loaded via this file will control other
+                                  options  [env var: C8YLP_ENV_FILE]
+  --store-token / --no-store-token
+                                  Store the Cumulocity host, tenant and token
+                                  to the env-file if a file is being used
+                                  [env var: C8YLP_STORE_TOKEN]
+  -d, --disable-prompts           [env var: C8YLP_DISABLE_PROMPTS]
+  -h, --help                      Show this message and exit.
 
 ```

--- a/docs/cli/C8YLP_PLUGIN_COMMAND.md
+++ b/docs/cli/C8YLP_PLUGIN_COMMAND.md
@@ -30,40 +30,44 @@ Usage: c8ylp plugin command [OPTIONS] DEVICE [REMOTE_COMMANDS]...
           c8ylp plugin command --env-file .env -v device01 ./copyfrom.sh /var/log/dpkg.log ./
 
 Options:
-  --host TEXT               Cumulocity Hostname  [required] [env var:
-                            C8Y_HOST]
-  -t, --tenant TEXT         Cumulocity tenant id  [env var: C8Y_TENANT]
-  -u, --user TEXT           Cumulocity username  [env var: C8Y_USER,
-                            C8Y_USERNAME]
-  -t, --token TEXT          Cumulocity token  [env var: C8Y_TOKEN]
-  -p, --password TEXT       Cumulocity password  [env var: C8Y_PASSWORD]
-  --tfa-code TEXT           TFA Code. Required when the 'TFA enabled' is
-                            enabled for a user  [env var: C8Y_TFA_CODE]
-  --env-file PATH           Environment file to load. Any settings loaded via
-                            this file will control other options  [env var:
-                            C8YLP_ENV_FILE]
-  --external-type TEXT      external Id Type  [env var: C8YLP_EXTERNAL_TYPE;
-                            default: c8y_Serial]
-  -c, --config TEXT         name of the C8Y Remote Access Configuration  [env
-                            var: C8YLP_CONFIG; default: Passthrough]
-  --port INTEGER RANGE      TCP Port which should be opened. 0=Random port
-                            [env var: C8YLP_PORT; default: 0; 0<=x<=65535]
-  --ping-interval INTEGER   Websocket ping interval in seconds. 0=disabled
-                            [env var: C8YLP_PING_INTERVAL; default: 0]
-  --tcp-size INTEGER RANGE  TCP Package Size  [env var: C8YLP_TCP_SIZE;
-                            default: 4096; 1024<=x<=8290304]
-  --tcp-timeout INTEGER     Timeout in sec. for inactivity. Can be activated
-                            with values > 0  [env var: C8YLP_TCP_TIMEOUT;
-                            default: 0]
-  -v, --verbose             Print Debug Information into the Logs and Console
-                            when set  [env var: C8YLP_VERBOSE]
-  --ignore-ssl-validate     Ignore Validation for SSL Certificates while
-                            connecting to Websocket  [env var:
-                            C8YLP_IGNORE_SSL_VALIDATE]
-  --store-token             Store the Cumulocity host, tenant and token to the
-                            env-file if a file is being used  [env var:
-                            C8YLP_STORE_TOKEN]
-  -d, --disable-prompts     [env var: C8YLP_DISABLE_PROMPTS]
-  -h, --help                Show this message and exit.
+  --host TEXT                     Cumulocity Hostname  [required] [env var:
+                                  C8Y_HOST]
+  -t, --tenant TEXT               Cumulocity tenant id  [env var: C8Y_TENANT]
+  -u, --user TEXT                 Cumulocity username  [env var: C8Y_USER,
+                                  C8Y_USERNAME]
+  --token TEXT                    Cumulocity token  [env var: C8Y_TOKEN]
+  -p, --password TEXT             Cumulocity password  [env var: C8Y_PASSWORD]
+  --tfa-code TEXT                 TFA Code. Required when the 'TFA enabled' is
+                                  enabled for a user  [env var: C8Y_TFA_CODE]
+  --env-file PATH                 Environment file to load. Any settings
+                                  loaded via this file will control other
+                                  options  [env var: C8YLP_ENV_FILE]
+  --external-type TEXT            external Id Type  [env var:
+                                  C8YLP_EXTERNAL_TYPE; default: c8y_Serial]
+  -c, --config TEXT               name of the C8Y Remote Access Configuration
+                                  [env var: C8YLP_CONFIG; default:
+                                  Passthrough]
+  --port INTEGER RANGE            TCP Port which should be opened. 0=Random
+                                  port  [env var: C8YLP_PORT; default: 0;
+                                  0<=x<=65535]
+  --ping-interval INTEGER         Websocket ping interval in seconds.
+                                  0=disabled  [env var: C8YLP_PING_INTERVAL;
+                                  default: 0]
+  --tcp-size INTEGER RANGE        TCP Package Size  [env var: C8YLP_TCP_SIZE;
+                                  default: 4096; 1024<=x<=8290304]
+  --tcp-timeout INTEGER           Timeout in sec. for inactivity. Can be
+                                  activated with values > 0  [env var:
+                                  C8YLP_TCP_TIMEOUT; default: 0]
+  -v, --verbose                   Print Debug Information into the Logs and
+                                  Console when set  [env var: C8YLP_VERBOSE]
+  --ignore-ssl-validate           Ignore Validation for SSL Certificates while
+                                  connecting to Websocket  [env var:
+                                  C8YLP_IGNORE_SSL_VALIDATE]
+  --store-token / --no-store-token
+                                  Store the Cumulocity host, tenant and token
+                                  to the env-file if a file is being used
+                                  [env var: C8YLP_STORE_TOKEN]
+  -d, --disable-prompts           [env var: C8YLP_DISABLE_PROMPTS]
+  -h, --help                      Show this message and exit.
 
 ```

--- a/docs/cli/C8YLP_SERVER.md
+++ b/docs/cli/C8YLP_SERVER.md
@@ -24,40 +24,44 @@ Usage: c8ylp server [OPTIONS] DEVICE
           c8ylp server --env-file .env --port 0 device01
 
 Options:
-  --host TEXT               Cumulocity Hostname  [required] [env var:
-                            C8Y_HOST]
-  -t, --tenant TEXT         Cumulocity tenant id  [env var: C8Y_TENANT]
-  -u, --user TEXT           Cumulocity username  [env var: C8Y_USER,
-                            C8Y_USERNAME]
-  -t, --token TEXT          Cumulocity token  [env var: C8Y_TOKEN]
-  -p, --password TEXT       Cumulocity password  [env var: C8Y_PASSWORD]
-  --tfa-code TEXT           TFA Code. Required when the 'TFA enabled' is
-                            enabled for a user  [env var: C8Y_TFA_CODE]
-  --env-file PATH           Environment file to load. Any settings loaded via
-                            this file will control other options  [env var:
-                            C8YLP_ENV_FILE]
-  --external-type TEXT      external Id Type  [env var: C8YLP_EXTERNAL_TYPE;
-                            default: c8y_Serial]
-  -c, --config TEXT         name of the C8Y Remote Access Configuration  [env
-                            var: C8YLP_CONFIG; default: Passthrough]
-  --port INTEGER RANGE      TCP Port which should be opened. 0=Random port
-                            [env var: C8YLP_PORT; default: 0; 0<=x<=65535]
-  --ping-interval INTEGER   Websocket ping interval in seconds. 0=disabled
-                            [env var: C8YLP_PING_INTERVAL; default: 0]
-  --tcp-size INTEGER RANGE  TCP Package Size  [env var: C8YLP_TCP_SIZE;
-                            default: 4096; 1024<=x<=8290304]
-  --tcp-timeout INTEGER     Timeout in sec. for inactivity. Can be activated
-                            with values > 0  [env var: C8YLP_TCP_TIMEOUT;
-                            default: 0]
-  -v, --verbose             Print Debug Information into the Logs and Console
-                            when set  [env var: C8YLP_VERBOSE]
-  --ignore-ssl-validate     Ignore Validation for SSL Certificates while
-                            connecting to Websocket  [env var:
-                            C8YLP_IGNORE_SSL_VALIDATE]
-  --store-token             Store the Cumulocity host, tenant and token to the
-                            env-file if a file is being used  [env var:
-                            C8YLP_STORE_TOKEN]
-  -d, --disable-prompts     [env var: C8YLP_DISABLE_PROMPTS]
-  -h, --help                Show this message and exit.
+  --host TEXT                     Cumulocity Hostname  [required] [env var:
+                                  C8Y_HOST]
+  -t, --tenant TEXT               Cumulocity tenant id  [env var: C8Y_TENANT]
+  -u, --user TEXT                 Cumulocity username  [env var: C8Y_USER,
+                                  C8Y_USERNAME]
+  --token TEXT                    Cumulocity token  [env var: C8Y_TOKEN]
+  -p, --password TEXT             Cumulocity password  [env var: C8Y_PASSWORD]
+  --tfa-code TEXT                 TFA Code. Required when the 'TFA enabled' is
+                                  enabled for a user  [env var: C8Y_TFA_CODE]
+  --env-file PATH                 Environment file to load. Any settings
+                                  loaded via this file will control other
+                                  options  [env var: C8YLP_ENV_FILE]
+  --external-type TEXT            external Id Type  [env var:
+                                  C8YLP_EXTERNAL_TYPE; default: c8y_Serial]
+  -c, --config TEXT               name of the C8Y Remote Access Configuration
+                                  [env var: C8YLP_CONFIG; default:
+                                  Passthrough]
+  --port INTEGER RANGE            TCP Port which should be opened. 0=Random
+                                  port  [env var: C8YLP_PORT; default: 0;
+                                  0<=x<=65535]
+  --ping-interval INTEGER         Websocket ping interval in seconds.
+                                  0=disabled  [env var: C8YLP_PING_INTERVAL;
+                                  default: 0]
+  --tcp-size INTEGER RANGE        TCP Package Size  [env var: C8YLP_TCP_SIZE;
+                                  default: 4096; 1024<=x<=8290304]
+  --tcp-timeout INTEGER           Timeout in sec. for inactivity. Can be
+                                  activated with values > 0  [env var:
+                                  C8YLP_TCP_TIMEOUT; default: 0]
+  -v, --verbose                   Print Debug Information into the Logs and
+                                  Console when set  [env var: C8YLP_VERBOSE]
+  --ignore-ssl-validate           Ignore Validation for SSL Certificates while
+                                  connecting to Websocket  [env var:
+                                  C8YLP_IGNORE_SSL_VALIDATE]
+  --store-token / --no-store-token
+                                  Store the Cumulocity host, tenant and token
+                                  to the env-file if a file is being used
+                                  [env var: C8YLP_STORE_TOKEN]
+  -d, --disable-prompts           [env var: C8YLP_DISABLE_PROMPTS]
+  -h, --help                      Show this message and exit.
 
 ```

--- a/tests/c8ylp/cli/test_login.py
+++ b/tests/c8ylp/cli/test_login.py
@@ -197,3 +197,156 @@ def test_help_without_host(env: Environment):
     assert result.exit_code == 0
     assert "Host: " not in result.output, "User should not be prompted for hostname"
     assert "dummyinput" not in result.output, "User should not be prompted for hostname"
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    (
+        {
+            "stdin": [],
+            "args": [
+                "--host",
+                "https://example.c8y.io",
+                "-u",
+                "myuser@company.com",
+                "-p",
+                "my-dummy45-password",
+                "-t",
+                "t12345",
+                "--token",
+                "98765",
+            ],
+            "env": {},
+        },
+    ),
+)
+def test_shorthand_login_options(
+    inputs, c8yserver: FixtureCumulocityAPI, env: Environment, tmpdir
+):
+    """Test shorthand options when logging in"""
+
+    @responses.activate
+    def run():
+        c8yserver.simulate_loginoptions()
+        c8yserver.simulate_login_oauth(status_codes=[401, 200])
+        c8yserver.simulate_current_user()
+
+        env_file = tmpdir.join(".env")
+        stdin = "".join(inputs["stdin"])
+
+        args = ["login", "--env-file", env_file.strpath, *inputs["args"]]
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            args,
+            env={
+                **env.create_empty_env(),
+                **inputs["env"],
+            },
+            input=stdin,
+        )
+
+        assert result.exit_code == 0
+
+        settings = env.read_file(env_file)
+        assert settings == {
+            "C8Y_HOST": "https://example.c8y.io",
+            "C8Y_USER": "myuser@company.com",
+            "C8Y_TENANT": "t12345",
+            "C8Y_TOKEN": "98765",
+        }
+
+    run()
+
+
+@pytest.mark.parametrize(
+    "inputs",
+    (
+        {
+            # Default behaviour is to store the token to the given --env-file
+            "stdin": [],
+            "args": ["--token", "98765"],
+            "env": {
+                "C8Y_HOST": "https://example.c8y.io",
+                "C8Y_USER": "myuser@company.com",
+                "C8Y_TENANT": "t12345",
+            },
+            "expected_env": {
+                "C8Y_HOST": "https://example.c8y.io",
+                "C8Y_USER": "myuser@company.com",
+                "C8Y_TENANT": "t12345",
+                "C8Y_TOKEN": "98765",
+            },
+        },
+        # User explicitly wants to store the token
+        {
+            "stdin": [],
+            "args": ["--token", "98765", "--store-token"],
+            "env": {
+                "C8Y_HOST": "https://example.c8y.io",
+                "C8Y_USER": "myuser@company.com",
+                "C8Y_TENANT": "t12345",
+            },
+            "expected_env": {
+                "C8Y_HOST": "https://example.c8y.io",
+                "C8Y_USER": "myuser@company.com",
+                "C8Y_TENANT": "t12345",
+                "C8Y_TOKEN": "98765",
+            },
+        },
+        # User explicitly does not want to store the token
+        {
+            "stdin": [],
+            "args": ["--token", "98765", "--no-store-token"],
+            "env": {
+                "C8Y_HOST": "https://example.c8y.io",
+                "C8Y_USER": "myuser@company.com",
+                "C8Y_TENANT": "t12345",
+            },
+            "expected_env": {
+                "C8Y_HOST": "https://example.c8y.io",
+                "C8Y_USER": "myuser@company.com",
+                "C8Y_TENANT": "t12345",
+            },
+        },
+    ),
+)
+def test_disable_token_storage(
+    inputs, c8yserver: FixtureCumulocityAPI, env: Environment, tmpdir
+):
+    """Test disabling of the token storage by excluding it from the environment file"""
+
+    @responses.activate
+    def run():
+        c8yserver.simulate_loginoptions()
+        c8yserver.simulate_login_oauth(status_codes=[401, 200])
+        c8yserver.simulate_current_user()
+
+        env_file = tmpdir.join(".env")
+
+        # Seed the env file with some default values
+        env_file.write_text(
+            "\n".join([f"{key}={value}" for key, value in inputs["env"].items()]),
+            "utf8",
+        )
+
+        stdin = "".join(inputs["stdin"])
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["login", "--env-file", env_file.strpath, *inputs["args"]],
+            env={
+                **env.create_empty_env(),
+                **inputs["env"],
+            },
+            input=stdin,
+        )
+
+        assert result.exit_code == 0
+
+        settings = env.read_file(env_file)
+        assert settings == inputs["expected_env"]
+
+    run()


### PR DESCRIPTION
* Remove duplicated `-t` shorthand option for the `--token` option. Fixes #45
* Add new option to disable storage of token in an dotenv file using `--no-store-token` (opposite of the existing `--store-token` option)