### PR TITLE
Fix/support ssh user via env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Releases
 
+## Current
+
+* `c8y connect ssh` supports reading the `--ssh-user` from the `C8YLP_SSH_USER` environment variable 
+
 ## 2.1.3
 
 * Remove duplicated `-t` shorthand option for the `--token` option. Fixes #45

--- a/c8ylp/cli/connect/ssh.py
+++ b/c8ylp/cli/connect/ssh.py
@@ -35,6 +35,8 @@ from c8ylp.cli.core import ExitCodes, ProxyContext
 @click.option(
     "--ssh-user",
     required=True,
+    envvar="C8YLP_SSH_USER",
+    show_envvar=True,
     prompt=True,
     help="SSH username which is configured on the device",
 )

--- a/c8ylp/options.py
+++ b/c8ylp/options.py
@@ -348,16 +348,6 @@ SERVER_RECONNECT_LIMIT = click.option(
     help="[Deprecated] No longer used but kept in for compatibility until next major release",
 )
 
-SSH_USER = click.option(
-    "--ssh-user",
-    envvar="C8YLP_SSH_USER",
-    type=str,
-    required=True,
-    prompt=True,
-    show_envvar=True,
-    help="Start an interactive ssh session with the given user",
-)
-
 ARG_SSH_COMMAND = click.argument("command", nargs=1, required=True)
 
 ARG_SCRIPT = click.argument(

--- a/docs/cli/C8YLP_CONNECT_SSH.md
+++ b/docs/cli/C8YLP_CONNECT_SSH.md
@@ -68,7 +68,7 @@ Options:
                                   [env var: C8YLP_STORE_TOKEN]
   -d, --disable-prompts           [env var: C8YLP_DISABLE_PROMPTS]
   --ssh-user TEXT                 SSH username which is configured on the
-                                  device  [required]
+                                  device  [env var: C8YLP_SSH_USER; required]
   -h, --help                      Show this message and exit.
 
 ```


### PR DESCRIPTION
* `c8y connect ssh` supports reading the `--ssh-user` from the `C8YLP_SSH_USER` environment variable or dotenv file