### PR TITLE
Add possibility to use unix domain socket instead of a normal port

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,18 @@ If you just want to connect via ssh using a once-off proxy instance using a rand
 c8ylp connect ssh <device> --ssh-user <device_username> --env-file .env
 ```
 
+### Usage with a socket path
+
+```sh
+c8ylp server <device> --env-file .env --socket-path /tmp/device.socket
+```
+
+then connect with ssh like:
+
+```sh
+ssh -o 'ProxyCommand=socat - UNIX-CLIENT:/tmp/device.socket' <device_username>@localhost
+```
+
 ### Command documentation
 
 The command usage and all options can be viewed online on the following pages:

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ c8ylp connect ssh <device> --ssh-user <device_username> --env-file .env
 
 ### Usage with a socket path
 
+**This is a unix only option**
+
 ```sh
 c8ylp server <device> --env-file .env --socket-path /tmp/device.socket
 ```

--- a/c8ylp/cli/core.py
+++ b/c8ylp/cli/core.py
@@ -672,11 +672,13 @@ def start_proxy(
                 f"\nc8ylp is listening for device (ext_id) {opts.device} ({opts.host}) on localhost:{opts.used_port}",
             )
             ssh_username = opts.ssh_user or "<device_username>"
-            opts.show_message(
-                f"\nFor example, if you are running a ssh proxy, you connect to {opts.device} by executing the "
-                "following in a new tab/console:\n\n"
-                f"\tssh -p {opts.used_port} {ssh_username}@localhost",
-            )
+            msg = f"\nFor example, if you are running a ssh proxy, you connect to {opts.device} by executing the " \
+                   "following in a new tab/console:\n\n"
+            if opts.socket_path:
+                msg += f"\tssh -o 'ProxyCommand=socat - UNIX-CLIENT:{opts.socket_path}' {ssh_username}@localhost"
+            else:
+                msg += f"\tssh -p {opts.used_port} {ssh_username}@localhost"
+            opts.show_message(msg)
 
             opts.show_info("\nPress ctrl-c to shutdown the server")
 

--- a/c8ylp/cli/core.py
+++ b/c8ylp/cli/core.py
@@ -638,7 +638,7 @@ def start_proxy(
     background = None
 
     try:
-        if opts.socket_path is not None:
+        if opts.socket_path:
             socket_server = UnixStreamProxyServer(
                 opts.socket_path,
                 WebsocketClient(**client_opts),

--- a/c8ylp/cli/core.py
+++ b/c8ylp/cli/core.py
@@ -25,6 +25,7 @@ import signal
 import threading
 import time
 import sys
+import socket
 from enum import IntEnum
 from logging.handlers import RotatingFileHandler
 from typing import Any, Dict, NoReturn, Optional
@@ -35,8 +36,11 @@ from ..timer import CommandTimer
 from ..banner import BANNER1
 from ..env import save_env
 from ..rest_client.c8yclient import CumulocityClient, CumulocityMissingTFAToken
-from ..tcp_socket import TCPProxyServer, UnixStreamProxyServer
+from ..tcp_socket import TCPProxyServer
 from ..websocket_client import WebsocketClient
+
+if hasattr(socket, "AF_UNIX"):
+    from ..tcp_socket import UnixStreamProxyServer
 
 
 class ExitCodes(IntEnum):

--- a/c8ylp/cli/core.py
+++ b/c8ylp/cli/core.py
@@ -35,7 +35,7 @@ from ..timer import CommandTimer
 from ..banner import BANNER1
 from ..env import save_env
 from ..rest_client.c8yclient import CumulocityClient, CumulocityMissingTFAToken
-from ..tcp_socket import TCPProxyServer
+from ..tcp_socket import TCPProxyServer, UnixStreamProxyServer
 from ..websocket_client import WebsocketClient
 
 
@@ -88,6 +88,7 @@ class ProxyContext:
     env_file = None
     store_token = False
     wait_port_timeout = 60.0
+    socket_path = ""
 
     def __init__(self, ctx: click.Context, src_dict: Dict[str, Any] = None) -> None:
         self._ctx = ctx
@@ -633,12 +634,20 @@ def start_proxy(
     background = None
 
     try:
-        tcp_server = TCPProxyServer(
-            opts.port,
-            WebsocketClient(**client_opts),
-            opts.tcp_size,
-            opts.tcp_timeout,
-        )
+        if opts.socket_path is not None:
+            tcp_server = UnixStreamProxyServer(
+                opts.socket_path,
+                WebsocketClient(**client_opts),
+                opts.tcp_size,
+                opts.tcp_timeout,
+            )
+        else:
+            tcp_server = TCPProxyServer(
+                opts.port,
+                WebsocketClient(**client_opts),
+                opts.tcp_size,
+                opts.tcp_timeout,
+            )
 
         exit_code = ExitCodes.OK
 

--- a/c8ylp/options.py
+++ b/c8ylp/options.py
@@ -19,6 +19,7 @@
 
 import logging
 import os
+import socket
 from typing import Any
 import functools
 
@@ -408,7 +409,6 @@ def common_options(f):
         EXTERNAL_IDENTITY_TYPE,
         REMOTE_ACCESS_TYPE,
         PORT_DEFAULT_RANDOM,
-        SOCKET_PATH,
         PING_INTERVAL,
         TCP_SIZE,
         TCP_TIMEOUT,
@@ -419,6 +419,8 @@ def common_options(f):
         SERVER_RECONNECT_LIMIT,
     ]
 
+    if hasattr(socket, "AF_UNIX"):
+        options.append(SOCKET_PATH)
     # Need to reverse the order to control the list order
     options = reversed(options)
     return functools.reduce(lambda x, opt: opt(x), options, f)

--- a/c8ylp/options.py
+++ b/c8ylp/options.py
@@ -243,6 +243,15 @@ C8Y_TFA_CODE = click.option(
     help="TFA Code. Required when the 'TFA enabled' is enabled for a user",
 )
 
+SOCKET_PATH = click.option(
+    "--socket-path",
+    type=str,
+    envvar="C8YLP_SOCKET_PATH",
+    show_envvar=True,
+    show_default=True,
+    help="Unix Socket Path which should be opened. Default None",
+)
+
 PORT = click.option(
     "--port",
     type=click.IntRange(0, 65535),
@@ -399,6 +408,7 @@ def common_options(f):
         EXTERNAL_IDENTITY_TYPE,
         REMOTE_ACCESS_TYPE,
         PORT_DEFAULT_RANDOM,
+        SOCKET_PATH,
         PING_INTERVAL,
         TCP_SIZE,
         TCP_TIMEOUT,

--- a/c8ylp/options.py
+++ b/c8ylp/options.py
@@ -150,6 +150,23 @@ def deprecated(ctx: click.Context, _param, value) -> Any:
     return value
 
 
+def supports_unix_socket(ctx, param, value) -> Any:
+    """OS supports unix sockets
+
+    Args:
+        ctx (Any): Click context
+        param (Any): Click param
+        value (Any): Parameter value
+
+    Returns:
+        Any: Parameter value
+    """
+    if value and not hasattr(socket, "AF_UNIX"):
+        print(param.name)
+        raise click.BadParameter("This option is only supported on Unix-like operating systems")
+    return value
+
+
 HOSTNAME = click.option(
     "--host",
     "host",
@@ -250,7 +267,8 @@ SOCKET_PATH = click.option(
     envvar="C8YLP_SOCKET_PATH",
     show_envvar=True,
     show_default=True,
-    help="Unix Socket Path which should be opened. Default None",
+    callback=supports_unix_socket,
+    help="Unix Only: Unix Socket Path which should be opened",
 )
 
 PORT = click.option(
@@ -417,10 +435,9 @@ def common_options(f):
         STORE_TOKEN,
         DISABLE_PROMPT,
         SERVER_RECONNECT_LIMIT,
+        SOCKET_PATH,
     ]
 
-    if hasattr(socket, "AF_UNIX"):
-        options.append(SOCKET_PATH)
     # Need to reverse the order to control the list order
     options = reversed(options)
     return functools.reduce(lambda x, opt: opt(x), options, f)

--- a/c8ylp/options.py
+++ b/c8ylp/options.py
@@ -161,9 +161,14 @@ def supports_unix_socket(ctx, param, value) -> Any:
     Returns:
         Any: Parameter value
     """
+    if not value or ctx.resilient_parsing:
+        return None
+
     if value and not hasattr(socket, "AF_UNIX"):
         print(param.name)
-        raise click.BadParameter("This option is only supported on Unix-like operating systems")
+        raise click.BadParameter(
+            "This option is only supported on Unix-like operating systems"
+        )
     return value
 
 

--- a/c8ylp/tcp_socket/__init__.py
+++ b/c8ylp/tcp_socket/__init__.py
@@ -17,4 +17,4 @@
 #
 """TCP socket"""
 
-from c8ylp.tcp_socket.tcp_server import TCPProxyServer
+from c8ylp.tcp_socket.tcp_server import TCPProxyServer, UnixStreamProxyServer

--- a/c8ylp/tcp_socket/__init__.py
+++ b/c8ylp/tcp_socket/__init__.py
@@ -16,5 +16,9 @@
 # limitations under the License.
 #
 """TCP socket"""
+import socket
 
-from c8ylp.tcp_socket.tcp_server import TCPProxyServer, UnixStreamProxyServer
+from c8ylp.tcp_socket.tcp_server import TCPProxyServer
+
+if hasattr(socket, "AF_UNIX"):
+    from c8ylp.tcp_socket.unix_stream_server import UnixStreamProxyServer

--- a/c8ylp/tcp_socket/tcp_server.py
+++ b/c8ylp/tcp_socket/tcp_server.py
@@ -17,6 +17,7 @@
 #
 """TCP server"""
 
+import os
 import errno
 import logging
 import socket
@@ -208,6 +209,7 @@ class UnixStreamProxyServer(TCPProxyServer):
         self.web_socket_client = web_socket_client
         self._running = threading.Event()
         self.logger = logging.getLogger(__name__)
+        self.path = path
 
         # Expose func to web socket client
         self.web_socket_client.proxy = self
@@ -219,3 +221,7 @@ class UnixStreamProxyServer(TCPProxyServer):
             buffer_size=tcp_buffer_size,
             tcp_timeout=tcp_timeout,
         )
+    def shutdown(self):
+        """Shutdown tcp server"""
+        super().shutdown()
+        os.remove(self.path)

--- a/c8ylp/tcp_socket/tcp_server.py
+++ b/c8ylp/tcp_socket/tcp_server.py
@@ -119,6 +119,7 @@ class CustomTCPServer(socketserver.TCPServer):
             server_address, RequestHandlerClass, bind_and_activate=bind_and_activate
         )
 
+
 class CustomUnixStreamServer(socketserver.UnixStreamServer):
     """Custom TCP Server used to listen for local connections and proxy them to
     a websocket
@@ -140,6 +141,7 @@ class CustomUnixStreamServer(socketserver.UnixStreamServer):
         super().__init__(
             server_address, RequestHandlerClass, bind_and_activate=bind_and_activate
         )
+
 
 class TCPProxyServer:
     """TCP Server"""
@@ -199,6 +201,11 @@ class TCPProxyServer:
 
 
 class UnixStreamProxyServer(TCPProxyServer):
+    """
+    Unix domain socket server
+    """
+
+    # pylint: disable=super-init-not-called
     def __init__(
         self,
         path,
@@ -221,6 +228,7 @@ class UnixStreamProxyServer(TCPProxyServer):
             buffer_size=tcp_buffer_size,
             tcp_timeout=tcp_timeout,
         )
+
     def shutdown(self):
         """Shutdown tcp server"""
         super().shutdown()

--- a/c8ylp/tcp_socket/unix_stream_server.py
+++ b/c8ylp/tcp_socket/unix_stream_server.py
@@ -1,0 +1,84 @@
+#
+# Copyright (c) 2021 Software AG, Darmstadt, Germany and/or its licensors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+""" Unix Stream Socket server"""
+
+
+import os
+import logging
+import threading
+import socketserver
+
+from c8ylp.tcp_socket.tcp_server import TCPProxyServer, TCPHandler
+
+
+class CustomUnixStreamServer(socketserver.UnixStreamServer):
+    """Custom TCP Server used to listen for local connections and proxy them to
+    a websocket
+    """
+
+    def __init__(
+        self,
+        web_socket_client,
+        server_address,
+        RequestHandlerClass,
+        bind_and_activate=True,
+        buffer_size: int = 1024,
+        tcp_timeout: float = 30,
+    ) -> None:
+        self.allow_reuse_address = True
+        self.timeout = tcp_timeout
+        self.buffer_size = buffer_size
+        self.web_socket_client = web_socket_client
+        super().__init__(
+            server_address, RequestHandlerClass, bind_and_activate=bind_and_activate
+        )
+
+
+class UnixStreamProxyServer(TCPProxyServer):
+    """
+    Unix domain socket server
+    """
+
+    # pylint: disable=super-init-not-called
+    def __init__(
+        self,
+        path,
+        web_socket_client,
+        tcp_buffer_size,
+        tcp_timeout,
+    ):
+        self.web_socket_client = web_socket_client
+        self._running = threading.Event()
+        self.logger = logging.getLogger(__name__)
+        self.path = path
+
+        # Expose func to web socket client
+        self.web_socket_client.proxy = self
+
+        self.server = CustomUnixStreamServer(
+            self.web_socket_client,
+            path,
+            TCPHandler,
+            buffer_size=tcp_buffer_size,
+            tcp_timeout=tcp_timeout,
+        )
+
+    def shutdown(self):
+        """Shutdown tcp server"""
+        super().shutdown()
+        os.remove(self.path)

--- a/tests/c8ylp/cli/test_server.py
+++ b/tests/c8ylp/cli/test_server.py
@@ -17,6 +17,7 @@
 #
 """Server tests"""
 
+import socket
 from unittest.mock import patch
 
 from click.testing import CliRunner
@@ -38,7 +39,7 @@ def test_server_mode(mock_context):
 
 @patch("c8ylp.cli.server.ProxyContext", autospec=True)
 def test_server_mode_socket_path(mock_context):
-    """Start a mocked server"""
+    """Start a mocked server using a unix socket. On windows an error will be returned"""
     mock_context.start.return_value = 0
 
     runner = CliRunner()
@@ -46,4 +47,5 @@ def test_server_mode_socket_path(mock_context):
         cli,
         ["server", "ext-device-01", "--socket-path", "/tmp/ext-device-01"],
     )
-    assert result.exit_code == 0
+    expect_exit_code = 0 if hasattr(socket, "AF_UNIX") else 2
+    assert result.exit_code == expect_exit_code

--- a/tests/c8ylp/cli/test_server.py
+++ b/tests/c8ylp/cli/test_server.py
@@ -34,3 +34,16 @@ def test_server_mode(mock_context):
         ["server", "ext-device-01"],
     )
     assert result.exit_code == 0
+
+
+@patch("c8ylp.cli.server.ProxyContext", autospec=True)
+def test_server_mode_socket_path(mock_context):
+    """Start a mocked server"""
+    mock_context.start.return_value = 0
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["server", "ext-device-01", "--socket-path", "/tmp/ext-device-01"],
+    )
+    assert result.exit_code == 0


### PR DESCRIPTION
If you supply the option --socket-path the proxy server will use the supplied path to create a unix domain socket instead of the localhost port.

This has many advantages in my opinion.

Best Regards Martin