### PR TITLE
Support stdin-/out forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,32 @@ then connect with ssh like:
 ssh -o 'ProxyCommand=socat - UNIX-CLIENT:/tmp/device.socket' <device_username>@localhost
 ```
 
+### Usage with stdin-/out forwarding
+
+Using stdin-/out forwarding to Cumulocity allows to use `c8ylp` as a proxy command without the need of a local TCP server.
+As proxy commands cannot interact with the user you have to ensure there is an active Cumulocity session.
+The session can be ensured by using the `c8ylp login --env-file .env` command that will update the environment file.
+As long as the session is active the Cumulocity server can be used as proxy command with `ssh` as following:
+
+```sh
+ssh -o 'ProxyCommand=c8ylp server <device> --stdio --env-file .env' <device_username>@<device>
+```
+
+By adding the proxy command to the `.ssh/config` file, the usage of the Cumulocity server can be simplified even more.
+The file allows to define user and environment file so the connection can be done by simply typing `ssh <device>`.
+For this use the following example configuration (`%n` will be replaced by `ssh` with the given device name):
+
+```console
+Host <device>
+    User <device_username>
+    PreferredAuthentications publickey
+    IdentityFile <identify_file>
+    ServerAliveInterval 120
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+    ProxyCommand c8ylp server %n --stdio --env-file .env
+```
+
 ### Command documentation
 
 The command usage and all options can be viewed online on the following pages:

--- a/c8ylp/options.py
+++ b/c8ylp/options.py
@@ -266,6 +266,17 @@ C8Y_TFA_CODE = click.option(
     help="TFA Code. Required when the 'TFA enabled' is enabled for a user",
 )
 
+STDIO = click.option(
+    "--stdio",
+    type=bool,
+    is_flag=True,
+    default=False,
+    envvar="C8YLP_STDIO",
+    show_envvar=True,
+    show_default=True,
+    help="Forward stdin/stdout to and from Cumulocity",
+)
+
 SOCKET_PATH = click.option(
     "--socket-path",
     type=str,
@@ -441,6 +452,7 @@ def common_options(f):
         DISABLE_PROMPT,
         SERVER_RECONNECT_LIMIT,
         SOCKET_PATH,
+        STDIO,
     ]
 
     # Need to reverse the order to control the list order

--- a/c8ylp/tcp_socket/__init__.py
+++ b/c8ylp/tcp_socket/__init__.py
@@ -19,6 +19,7 @@
 import socket
 
 from c8ylp.tcp_socket.tcp_server import TCPProxyServer
+from c8ylp.tcp_socket.stdio_server import StdioProxyServer
 
 if hasattr(socket, "AF_UNIX"):
     from c8ylp.tcp_socket.unix_stream_server import UnixStreamProxyServer

--- a/c8ylp/tcp_socket/stdio_server.py
+++ b/c8ylp/tcp_socket/stdio_server.py
@@ -1,0 +1,113 @@
+#
+# Copyright (c) 2022 Software AG, Darmstadt, Germany and/or its licensors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+""" Stdin/Stdout forwarding server"""
+import io
+import logging
+import sys
+import threading
+
+from c8ylp.tcp_socket.tcp_server import TCPProxyServer
+
+
+class StdioHandler:
+    """
+    The request handler class for our server.
+
+    It is instantiated once and used to forward stdin/stdout to the websocket
+    """
+
+    def __init__(self, web_socket_client, buffer_size):
+        self.web_socket_client = web_socket_client
+        self.buffer_size = buffer_size
+        self.shutdown_event = threading.Event()
+        self.socket = None
+        self._reader = None
+        self._writer = None
+
+    def shutdown(self):
+        """Shutdown tcp server"""
+        self.shutdown_event.set()
+        self._reader.close()
+        self._writer.close()
+
+    def serve_forever(self):
+        """stdio "connection" handler"""
+        with io.open(
+            sys.stdin.fileno(), mode="rb", closefd=False, buffering=0
+        ) as self._reader, io.open(
+            sys.stdout.fileno(), mode="wb", closefd=False, buffering=0
+        ) as self._writer:
+
+            self.web_socket_client.shutdown_request = self.shutdown
+
+            # connect websocket
+            if not self.web_socket_client.is_open():
+                self.web_socket_client.connect()
+
+            # update link to current stdin/stdout send
+            request_error = False
+
+            def safe_send(data):
+                nonlocal request_error
+                try:
+                    if not request_error:
+                        self._writer.write(data)
+                except OSError as ex:
+                    request_error = True
+                    logging.error(ex)
+
+            self.web_socket_client.proxy_send_message = safe_send
+
+            while not self.shutdown_event.is_set():
+                try:
+                    logging.debug("Reading from stdin")
+                    data = self._reader.read(self.buffer_size or 1024)
+                    logging.debug("stdin wrote: %s", data)
+                    if not data:
+                        logging.debug("No data. Request will be closed")
+                        self.web_socket_client.proxy_send_message = None
+                        self.web_socket_client.stop()
+                        break
+
+                    logging.debug("Writing data to ws: %s", data)
+                    self.web_socket_client.send_binary(data)
+                    logging.debug("Wrote data to ws: %s", data)
+                except (ConnectionResetError, OSError) as ex:
+                    logging.info("Connection was reset. %s", ex)
+                    break
+
+
+class StdioProxyServer(TCPProxyServer):
+    """
+    Stdin/Stdout forwarding server
+    """
+
+    # pylint: disable=super-init-not-called
+    def __init__(
+        self,
+        web_socket_client,
+        buffer_size,
+    ):
+        self.web_socket_client = web_socket_client
+        self._running = threading.Event()
+        self.logger = logging.getLogger(__name__)
+
+        # Expose func to web socket client
+        self.web_socket_client.proxy = self
+
+        self.server = StdioHandler(self.web_socket_client, buffer_size)

--- a/docs/cli/C8YLP_SERVER.md
+++ b/docs/cli/C8YLP_SERVER.md
@@ -64,6 +64,8 @@ Options:
   -d, --disable-prompts           [env var: C8YLP_DISABLE_PROMPTS]
   --socket-path TEXT              Unix Only: Unix Socket Path which should be
                                   opened  [env var: C8YLP_SOCKET_PATH]
+  --stdio                         Forward stdin/stdout to and from Cumulocity
+                                  [env var: C8YLP_STDIO; default: False]
   -h, --help                      Show this message and exit.
 
 ```

--- a/tests_integration/test_ssh.py
+++ b/tests_integration/test_ssh.py
@@ -18,6 +18,7 @@
 """Test plugin command"""
 
 import os
+import shutil
 import subprocess
 import sys
 
@@ -39,6 +40,46 @@ def proxy_cli(*args, **kwargs) -> subprocess.CompletedProcess:
         stderr=subprocess.PIPE,
         **kwargs,
     )
+
+
+def stdio_cli(*args, **kwargs) -> subprocess.CompletedProcess:
+    """Execute the proxy cli command using stdin/out forwarding"""
+    if not shutil.which("ssh"):
+        pytest.fail("ssh client not found. Please make sure the 'ssh' client is included in your PATH variable")
+
+    return subprocess.run(
+        [
+            'ssh',
+            '-o',
+            f'ProxyCommand={sys.executable} -m c8ylp server %n --stdio --env-file .env',
+            *args,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize(
+    "case",
+    (
+        dict(command="sleep 1s", exit_code=0),
+        dict(command="sleep 1s; exit 111", exit_code=111),
+        dict(command="sleep 1s; exit 111", user="unknown_user", exit_code=255),
+    ),
+    ids=lambda x: str(x),
+)
+def test_stdio_ssh_command_then_exit(case, c8ydevice: Device):
+    """Test running a once off ssh command"""
+    user = case.get("user", c8ydevice.ssh_user)
+    command = case.get("command", "sleep 10s")
+
+    result = stdio_cli(
+        f'{user}@{c8ydevice.device}',
+        command,
+    )
+
+    assert result.returncode == case.get("exit_code", 0)
 
 
 @pytest.mark.parametrize(

--- a/tests_integration/test_ssh.py
+++ b/tests_integration/test_ssh.py
@@ -45,13 +45,15 @@ def proxy_cli(*args, **kwargs) -> subprocess.CompletedProcess:
 def stdio_cli(*args, **kwargs) -> subprocess.CompletedProcess:
     """Execute the proxy cli command using stdin/out forwarding"""
     if not shutil.which("ssh"):
-        pytest.fail("ssh client not found. Please make sure the 'ssh' client is included in your PATH variable")
+        pytest.fail(
+            "ssh client not found. Please make sure the 'ssh' client is included in your PATH variable"
+        )
 
     return subprocess.run(
         [
-            'ssh',
-            '-o',
-            f'ProxyCommand={sys.executable} -m c8ylp server %n --stdio --env-file .env',
+            "ssh",
+            "-o",
+            f"ProxyCommand={sys.executable} -m c8ylp server %n --stdio --env-file .env",
             *args,
         ],
         stdout=subprocess.PIPE,
@@ -75,7 +77,7 @@ def test_stdio_ssh_command_then_exit(case, c8ydevice: Device):
     command = case.get("command", "sleep 10s")
 
     result = stdio_cli(
-        f'{user}@{c8ydevice.device}',
+        f"{user}@{c8ydevice.device}",
         command,
     )
 

--- a/tests_integration/test_ssh.py
+++ b/tests_integration/test_ssh.py
@@ -53,6 +53,8 @@ def stdio_cli(*args, **kwargs) -> subprocess.CompletedProcess:
         [
             "ssh",
             "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
             f"ProxyCommand={sys.executable} -m c8ylp server %n --stdio --env-file .env",
             *args,
         ],


### PR DESCRIPTION
By adding support for stdin-/out forwarding to the Cumulosity server it can be used directly as a ProxyCommand without the need of starting a local TCP server and using `socat`. Also this method works for both, windows and unix.
As `ProxyCommand` is not supporting user interaction, this method requires a active Cumulosity session and will fail otherwise without retry.