### PR TITLE
use second without units for improve compatibility with sleep on MacOS

### DIFF
--- a/tests_integration/test_command.py
+++ b/tests_integration/test_command.py
@@ -46,9 +46,9 @@ def proxy_cli(*args) -> subprocess.CompletedProcess:
 @pytest.mark.parametrize(
     "case",
     (
-        dict(clients=1, delay=10, command="sleep 10s"),
-        dict(clients=2, delay=10, command="sleep 10s"),
-        dict(clients=5, delay=7, command="sleep 10s"),
+        dict(clients=1, delay=10, command="sleep 10"),
+        dict(clients=2, delay=10, command="sleep 10"),
+        dict(clients=5, delay=7, command="sleep 10"),
     ),
     ids=lambda x: str(x),
 )
@@ -56,7 +56,7 @@ def test_concurrent_commands(case, c8ydevice: Device):
     """Test running concurrent commands"""
     clients = case.get("clients")
     delay = case.get("delay", 0.1)
-    command = case.get("command", "sleep 10s")
+    command = case.get("command", "sleep 10")
 
     threads: List[threading.Thread] = []
     results: List[subprocess.CompletedProcess] = [None] * clients

--- a/tests_integration/test_ssh.py
+++ b/tests_integration/test_ssh.py
@@ -67,16 +67,16 @@ def stdio_cli(*args, **kwargs) -> subprocess.CompletedProcess:
 @pytest.mark.parametrize(
     "case",
     (
-        dict(command="sleep 1s", exit_code=0),
-        dict(command="sleep 1s; exit 111", exit_code=111),
-        dict(command="sleep 1s; exit 111", user="unknown_user", exit_code=255),
+        dict(command="sleep 1", exit_code=0),
+        dict(command="sleep 1; exit 111", exit_code=111),
+        dict(command="sleep 1; exit 111", user="unknown_user", exit_code=255),
     ),
     ids=lambda x: str(x),
 )
 def test_stdio_ssh_command_then_exit(case, c8ydevice: Device):
     """Test running a once off ssh command"""
     user = case.get("user", c8ydevice.ssh_user)
-    command = case.get("command", "sleep 10s")
+    command = case.get("command", "sleep 10")
 
     result = stdio_cli(
         f"{user}@{c8ydevice.device}",
@@ -89,16 +89,16 @@ def test_stdio_ssh_command_then_exit(case, c8ydevice: Device):
 @pytest.mark.parametrize(
     "case",
     (
-        dict(command="sleep 1s", exit_code=0),
-        dict(command="sleep 1s; exit 111", exit_code=111),
-        dict(command="sleep 1s; exit 111", user="unknown_user", exit_code=255),
+        dict(command="sleep 1", exit_code=0),
+        dict(command="sleep 1; exit 111", exit_code=111),
+        dict(command="sleep 1; exit 111", user="unknown_user", exit_code=255),
     ),
     ids=lambda x: str(x),
 )
 def test_ssh_command_then_exit(case, c8ydevice: Device):
     """Test running a once off ssh command"""
     user = case.get("user", c8ydevice.ssh_user)
-    command = case.get("command", "sleep 10s")
+    command = case.get("command", "sleep 10")
 
     result = proxy_cli(
         "connect",
@@ -115,13 +115,13 @@ def test_ssh_command_then_exit(case, c8ydevice: Device):
 
 @pytest.mark.parametrize(
     "case",
-    (dict(command="sleep 1s", exit_code=0),),
+    (dict(command="sleep 1", exit_code=0),),
     ids=lambda x: str(x),
 )
 def test_support_ssh_user_via_env(case, c8ydevice: Device):
     """Test ssh command should support setting the ssh user via env variable"""
     user = case.get("user", c8ydevice.ssh_user)
-    command = case.get("command", "sleep 10s")
+    command = case.get("command", "sleep 10")
 
     result = proxy_cli(
         "connect",


### PR DESCRIPTION
Use `sleep 1` instead of `sleep 1s` as the latter is not support on some `sleep` commands (most notably on MacOS).

This only applies to the integration tests so that they can also be run on MacOS.