### PR TITLE
feat: Fallback to first PASSTHROUGH config when no matches found

### DIFF
--- a/c8ylp/cli/core.py
+++ b/c8ylp/cli/core.py
@@ -498,6 +498,8 @@ def get_config_id(ctx: click.Context, mor: Dict[str, Any], config: str) -> str:
         )
         return extract_config_id(valid_configs[0])
 
+    # Technically it should never reach here, however leave in place in
+    # case the above logic is changed
     logging.error(
         'Provided config name "%s" for "%s" was not found or none with protocol set to "%s"',
         config,

--- a/c8ylp/cli/core.py
+++ b/c8ylp/cli/core.py
@@ -487,7 +487,8 @@ def get_config_id(ctx: click.Context, mor: Dict[str, Any], config: str) -> str:
 
     if matches:
         return extract_config_id(matches[0])
-    elif valid_configs:
+
+    if valid_configs:
         # Fallback to using the first valid config (if not matches names were found)
         logging.warning(
             "No matching %s configs found (name=%s), so falling back to first config (name=%s)",

--- a/tasks.py
+++ b/tasks.py
@@ -21,6 +21,15 @@ import re
 import shutil
 import subprocess
 import sys
+
+# WORKAROUND
+# Workaround until python 3.11 is supported by py-invoke
+# https://github.com/pyinvoke/invoke/issues/833#issuecomment-1293148106
+import inspect
+
+if not hasattr(inspect, "getargspec"):
+    inspect.getargspec = inspect.getfullargspec
+
 from invoke import task
 from pathlib import Path
 

--- a/tests/c8ylp/cli/connect/test_ssh.py
+++ b/tests/c8ylp/cli/connect/test_ssh.py
@@ -329,14 +329,23 @@ def test_missing_role(c8yserver: FixtureCumulocityAPI, env: Environment):
             "exit_code": ExitCodes.DEVICE_NO_PASSTHROUGH_CONFIG,
         },
         {
-            "description": "Missing matching PASSTHROUGH name",
+            "description": "Not an exact PASSTHROUGH name match",
             "fragments": {
                 REMOTE_ACCESS_FRAGMENT: [
                     {"id": 1, "name": "example-ssh", "protocol": "ssh"},
                     {"id": 2, "name": "custom-passthrough", "protocol": PASSTHROUGH},
                 ]
             },
-            "exit_code": ExitCodes.DEVICE_NO_MATCHING_PASSTHROUGH_CONFIG,
+            "exit_code": ExitCodes.MISSING_ROLE_REMOTE_ACCESS_ADMIN,
+        },
+        {
+            "description": "Missing matching PASSTHROUGH name",
+            "fragments": {
+                REMOTE_ACCESS_FRAGMENT: [
+                    {"id": 1, "name": "example-ssh", "protocol": "ssh"},
+                ]
+            },
+            "exit_code": ExitCodes.DEVICE_NO_PASSTHROUGH_CONFIG,
         },
         {
             "description": "Custom PASSTHROUGH name matching but still missing role",


### PR DESCRIPTION
Make `c8ylp` more flexible when trying to find a matching remote access PASSTHROUGH configuration. By default `c8ylp` tries to find a `PASSTHROUGH` configuration item with a specific name (defaults to `Passthrough`). Whilst the user can change this via the `--config <name>` flag, it does not make it very adaptable to different setups.

Now if `c8ylp` can't find a remote access config matching the given name, it will fallback to using the first configuration item with type `PASSTHROUGH`. In this case it will also print a warning alerting  the user that another configuration name was selected, however it still tries to connect using it.

**Example when the config does not match**

```
cumulocity-remote-access-local-proxy % python3 -m c8ylp connect ssh TST-import_commutative_width --ssh-user example  -v
Validating c8y token: OK
[c8ylp]  INFO  Checking tenant id
[c8ylp]  WARNING No matching PASSTHROUGH configs found (name=Passthrough), so falling back to first config (name=native-ssh)
[c8ylp]  INFO  Using Configuration with Name "native-ssh" and Remote Port 22

        _           
     _ (_)    | ._  
    (_ (_) \/ | |_) 
           /    |   
Cumulocity Local Proxy

[c8ylp]  INFO  Starting socket server
```