### PR TITLE
Disconnect TCP peer when Web Socket is closed

### DIFF
--- a/c8ylp/tcp_socket/tcp_server.py
+++ b/c8ylp/tcp_socket/tcp_server.py
@@ -49,6 +49,7 @@ class TCPHandler(socketserver.BaseRequestHandler):
             # Note: fileno is set to -1 if the socket has been closed
             if request.fileno() != -1:
                 request.shutdown(socket.SHUT_RDWR)
+                request.close()
 
         self.server.web_socket_client.shutdown_request = handle_shutdown
 

--- a/c8ylp/websocket_client/ws_client.py
+++ b/c8ylp/websocket_client/ws_client.py
@@ -239,6 +239,8 @@ class WebsocketClient(threading.Thread):
             lookup_close_status_code(close_status),
             reason,
         )
+        if callable(self.shutdown_request):
+            self.shutdown_request()
         self._ws_open_event.clear()
 
     def _on_ws_open(self, _ws):


### PR DESCRIPTION
Fixes #114 
Shutting down the peer connection when ws is disconnected / closed.
Server will be kept open to accept new peer connections.