### PR TITLE
feat: write user messages to stderr

### DIFF
--- a/c8ylp/cli/core.py
+++ b/c8ylp/cli/core.py
@@ -184,12 +184,12 @@ class ProxyContext:
 
     @classmethod
     def show_message(cls, msg: str, *args, **kwargs):
-        """Show an message to the user and log it
+        """Show an message to the user (on stderr) and log it
 
         Args:
             msg (str): User message to print on the console
         """
-        click.secho(msg, fg="green")
+        click.secho(msg, fg="green", err=True)
         logging.info(msg, *args, **kwargs)
 
     def show_error(self, msg: str, *args, **kwargs):
@@ -204,13 +204,13 @@ class ProxyContext:
         logging.warning(msg, *args, **kwargs)
 
     def show_info(self, msg: str, *args, **kwargs):
-        """Show an info message to the user and log it
+        """Show an info message to the user (on stderr) and log it
 
         Args:
             msg (str): User message to print on the console
         """
         if not self.verbose:
-            click.secho(msg)
+            click.secho(msg, err=True)
 
         logging.warning(msg, *args, **kwargs)
 
@@ -574,7 +574,11 @@ def run_proxy_in_background(
     opts.set_env()
 
     # The subcommand is called after this
-    timer = CommandTimer("Duration", on_exit=click.echo).start()
+    def display(*args, **kwargs):
+        kwargs["err"] = True
+        click.echo(*args, **kwargs)
+
+    timer = CommandTimer("Duration", on_exit=display).start()
 
     # Shutdown the server once the plugin has been run
     @ctx.call_on_close
@@ -701,7 +705,7 @@ def start_proxy(
                 opts.tcp_timeout,
             )
 
-        click.secho(BANNER1)
+        click.secho(BANNER1, err=True)
         logging.info("Starting socket server")
 
         background = threading.Thread(target=socket_server.serve_forever, daemon=True)

--- a/c8ylp/helper.py
+++ b/c8ylp/helper.py
@@ -122,7 +122,7 @@ def cli_wait(ctx: click.Context, port, timeout, silent):
         wait_for_port(port, timeout, silent)
     except TimeoutError:
         if not silent:
-            click.secho(f"Port is not open after {timeout}s", fg="red")
+            click.secho(f"Port is not open after {timeout}s", fg="red", err=True)
         ctx.exit(1)
 
 

--- a/c8ylp/options.py
+++ b/c8ylp/options.py
@@ -96,11 +96,11 @@ def validate_token(ctx: click.Context, _param, value) -> Any:
 
     try:
         client.validate_credentials()
-        click.secho("Validating c8y token: ", nl=False)
-        click.secho("OK", fg="green")
+        click.secho("Validating c8y token: ", nl=False, err=True)
+        click.secho("OK", fg="green", err=True)
     except Exception:
-        click.secho("Validating c8y token: ", nl=False)
-        click.secho("EXPIRED/INVALID", fg="red")
+        click.secho("Validating c8y token: ", nl=False, err=True)
+        click.secho("EXPIRED/INVALID", fg="red", err=True)
         logging.info(
             "Token is no longer valid for host. The token will be ignored. host=%s",
             host,


### PR DESCRIPTION
Write user messages to stderr (instead of stdout).

Using stderr for user messages is generally the [standard](https://pubs.opengroup.org/onlinepubs/9699919799/functions/stderr.html), and it then allows users to ignore the messages by simply redirecting stderr to `/dev/null` (mostly useful for when using `c8ylp connect ssh mydevice -- <REMOTE_COMMAND>` which allows the user to only concentrate on the more stdout.