### PR TITLE
feat: allow users to provide device's managed object id instead of the external identity

### DIFF
--- a/c8ylp/cli/connect/ssh.py
+++ b/c8ylp/cli/connect/ssh.py
@@ -55,7 +55,7 @@ def cli(ctx: click.Context, ssh_user: str, additional_args: List[str], **kwargs)
     from being interpreted by c8ylp (i.e. to avoid clashes with c8ylp).
 
     \b
-        DEVICE is the device's external identity
+        DEVICE is the device's external identity or managed object id
 
     Example 1: Start an interactive SSH connection
 

--- a/c8ylp/cli/server.py
+++ b/c8ylp/cli/server.py
@@ -34,7 +34,7 @@ def server(
     """Start local proxy in server mode
 
     \b
-        DEVICE is the device's external identity
+        DEVICE is the device's external identity or managed object id
 
     Once the local proxy has started, clients such as ssh and scp can be used
     to establish a connection to the device.

--- a/c8ylp/plugins/command.py
+++ b/c8ylp/plugins/command.py
@@ -43,7 +43,7 @@ def cli(ctx: click.Context, additional_args: List[str], **kwargs):
     Start once-off proxy and execute a (local) script/command
 
         \b
-        DEVICE is the device's external identity
+        DEVICE is the device's external identity or managed object id
         REMOTE_COMMANDS is the script or command to run after the proxy has been started
 
         All additional arguments will be passed to the script/command. Use "--" before

--- a/docs/cli/C8YLP_CONNECT_SSH.md
+++ b/docs/cli/C8YLP_CONNECT_SSH.md
@@ -13,7 +13,7 @@ Usage: c8ylp connect ssh [OPTIONS] DEVICE [REMOTE_COMMANDS]...
   Use "--" before the remote commands to prevent the arguments from being
   interpreted by c8ylp (i.e. to avoid clashes with c8ylp).
 
-      DEVICE is the device's external identity
+      DEVICE is the device's external identity or managed object id
 
   Example 1: Start an interactive SSH connection
 

--- a/docs/cli/C8YLP_PLUGIN_COMMAND.md
+++ b/docs/cli/C8YLP_PLUGIN_COMMAND.md
@@ -6,7 +6,7 @@ Usage: c8ylp plugin command [OPTIONS] DEVICE [REMOTE_COMMANDS]...
 
   Start once-off proxy and execute a (local) script/command
 
-          DEVICE is the device's external identity
+          DEVICE is the device's external identity or managed object id
           REMOTE_COMMANDS is the script or command to run after the proxy has been started
 
       All additional arguments will be passed to the script/command. Use "--"

--- a/docs/cli/C8YLP_SERVER.md
+++ b/docs/cli/C8YLP_SERVER.md
@@ -6,7 +6,7 @@ Usage: c8ylp server [OPTIONS] DEVICE
 
   Start local proxy in server mode
 
-      DEVICE is the device's external identity
+      DEVICE is the device's external identity or managed object id
 
   Once the local proxy has started, clients such as ssh and scp can be used to
   establish a connection to the device.


### PR DESCRIPTION
Allowing user's to provide the managed object id allows better integration with other tooling (e.g. go-c8y-cli). This allows other tooling to perform custom lookups to retrieve the managed object id and just pass that to c8ylp when it it started.

The new managed object id/external identity logic is as follows:

If the given input is numeric (only digits), then try looking up if it corresponds to a managed object id. If successful, then use the managed object result, otherwise try treat the input as an external identity. If the input is not numeric, then assume the input is an external identity (same behaviour as before).

Below shows an example that should now work:

```sh
c8ylp connect ssh 12345 --ssh-user linuxuser
```